### PR TITLE
Support naming toolchains and --force

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustup-toolchain-install-master"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup-toolchain-install-master"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["kennytm <kennytm@gmail.com>"]
 description = "Install master rustc toolchain into rustup"
 repository = "https://github.com/kennytm/rustup-toolchain-install-master"


### PR DESCRIPTION
It's easier to call `cargo +master build` or whatever. We may even want the default to be `master` when invoked with no commit hash.

Currently it's annoying to use this in CI since I have to recalculate the hash so that I can use the toolchain.

r? @kennytm`