### PR TITLE
Use CDN to download artifacts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ struct Args {
         short = "s",
         long = "server",
         help = "the server path which stores the compilers",
-        default_value = "https://rust-lang-ci2.s3-us-west-1.amazonaws.com"
+        default_value = "https://ci-artifacts.rust-lang.org"
     )]
     server: String,
 


### PR DESCRIPTION
This should both be faster (especially outside the US) and is cheaper for the infra team than hitting S3 directly.

cc @pietroalbini -- finally got around to doing this here