### PR TITLE
replace ansi_term by colored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +215,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1160,9 +1160,9 @@ dependencies = [
 name = "rustup-toolchain-install-master"
 version = "1.8.1"
 dependencies = [
- "ansi_term",
  "anyhow",
  "clap",
+ "colored",
  "home",
  "pbr",
  "remove_dir_all",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-issue-resolution = { repository = "kennytm/rustup-toolchain-ins
 is-it-maintained-open-issues = { repository = "kennytm/rustup-toolchain-install-master" }
 
 [dependencies]
-ansi_term = "0.12"
+colored = "3"
 anyhow = "1.0.31"
 home = "0.5"
 pbr = "1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::process::exit;
 use std::process::Command;
 use std::time::Duration;
 
-use ansi_term::Color::{Red, Yellow};
+use colored::Colorize;
 use anyhow::{bail, ensure, Context, Error};
 use clap::{crate_version, Parser};
 use pbr::{ProgressBar, Units};
@@ -499,17 +499,17 @@ fn run() -> Result<(), Error> {
 }
 
 fn report_error(err: &Error) {
-    eprintln!("{} {}", Red.bold().paint("error:"), err);
+    eprintln!("{} {}", "error:".red().bold(), err);
     for cause in err.chain().skip(1) {
-        eprintln!("{} {}", Red.bold().paint("caused by:"), cause);
+        eprintln!("{} {}", "caused by:".red().bold(), cause);
     }
     exit(1);
 }
 
 fn report_warn(warn: &Error) {
-    eprintln!("{} {}", Yellow.bold().paint("warn:"), warn);
+    eprintln!("{} {}", "warn:".yellow().bold(), warn);
     for cause in warn.chain().skip(1) {
-        eprintln!("{} {}", Yellow.bold().paint("caused by:"), cause);
+        eprintln!("{} {}", "caused by:".yellow().bold(), cause);
     }
     eprintln!();
 }


### PR DESCRIPTION
This removes one of the transitive dependencies on winapi, which brings us one step closer to https://github.com/rust-lang/miri/pull/4479.

The other dependency is via `pbr`, see https://github.com/a8m/pb/issues/123. Not sure if there is an alternative one can easily switch to, or whether we have to wait until that crate has been ported away from winapi.