### PR TITLE
Added retry loop when downloading *.xz files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "as-slice"
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.37"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -102,9 +102,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -130,15 +130,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -148,9 +148,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -178,9 +178,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -212,24 +212,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "compression-core",
  "flate2",
@@ -408,6 +408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,9 +444,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -448,33 +454,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -482,7 +488,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -508,9 +513,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -530,6 +548,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -737,6 +764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,20 +797,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -791,9 +826,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -804,7 +839,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -813,9 +848,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -829,36 +886,45 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags",
  "libc",
+ "plain",
  "redox_syscall",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -891,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -913,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -945,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -980,9 +1046,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -995,6 +1061,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1012,6 +1084,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1081,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1093,6 +1175,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1125,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -1148,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -1202,15 +1290,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1221,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1296,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-toolchain-install-master"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1328,18 +1416,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -1350,13 +1438,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1389,6 +1483,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,9 +1503,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1414,12 +1521,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1442,9 +1549,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1511,12 +1618,12 @@ checksum = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1574,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1589,9 +1696,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1701,9 +1808,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1770,10 +1883,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1784,23 +1906,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1808,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1821,18 +1939,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2137,6 +2289,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2188,18 +2422,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2265,3 +2499,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup-toolchain-install-master"
-version = "1.11.0"
+version = "1.12.0"
 authors = ["kennytm <kennytm@gmail.com>"]
 categories = ["development-tools"]
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ Options:
   -n, --name <NAME>                  the name to call the toolchain
   -a, --alt                          download the alt build instead of normal build
   -s, --server <SERVER>              the server path which stores the compilers [default: https://ci-artifacts.rust-lang.org]
-  -i, --host <HOST>                  the triple of the host platform
-  -t, --targets <TARGETS>            additional target platforms to install rust-std for, besides the host platform
-  -c, --component <COMPONENTS>       additional components to install, besides rustc and rust-std
+  -i, --host <HOST>                  the triple of the host platform [default: x86_64-unknown-linux-gnu]
+  -t, --targets <TARGETS>...         additional target platforms to install rust-std for, besides the host platform
+  -c, --component <COMPONENTS>...    additional components to install, besides rustc and rust-std
       --channel <CHANNEL>            specify the channel of the commits instead of detecting it automatically
   -p, --proxy <PROXY>                the HTTP proxy for all download requests
       --github-token <GITHUB_TOKEN>  An authorization token to access GitHub APIs
       --dry-run                      Only log the URLs, without downloading the artifacts
   -f, --force                        Replace an existing toolchain of the same name
   -k, --keep-going                   Continue downloading toolchains even if some of them failed
+  -r, --retry <RETRY>                Maximum number of retries for xz downloads [default: 0]
   -h, --help                         Print help
   -V, --version                      Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 
+use std::borrow::Cow;
 use std::env::set_current_dir;
 use std::fs::{create_dir_all, rename};
 use std::io::{Write, stderr, stdout};
@@ -156,6 +157,7 @@ impl<E: Into<Error>> From<E> for RetryableError {
 struct TarXzDownloader<'a> {
     client: Option<&'a Client>,
     toolchain: &'a Toolchain<'a>,
+    channel: &'a str,
     retry: u32,
 }
 
@@ -202,7 +204,7 @@ impl<'a> TarXzDownloader<'a> {
                         anyhow!(
                             "missing component `{component}` on toolchain `{}` on channel `{}` for target `{target}`",
                             self.toolchain.commit,
-                            self.toolchain.channel,
+                            self.channel,
                         )
                     } else {
                         anyhow!("received status {status} for GET {url}")
@@ -283,83 +285,96 @@ struct Toolchain<'a> {
     host_target: &'a str,
     rust_std_targets: &'a [&'a str],
     components: &'a [&'a str],
-    channel: &'a str,
     dest: PathBuf,
 }
 
-fn install_single_toolchain(
-    maybe_dry_client: Option<&Client>,
-    prefix: &str,
-    toolchains_path: &Path,
-    toolchain: &Toolchain<'_>,
+struct Installer<'a> {
+    client: &'a Client,
+    actually_install: bool,
+    override_channel: Option<&'a str>,
+    prefix: &'a str,
+    toolchains_path: &'a Path,
     force: bool,
     retry: u32,
-) -> Result<(), Error> {
-    let toolchain_path = toolchains_path.join(&toolchain.dest);
-    if toolchain_path.is_dir() {
-        if force {
-            if maybe_dry_client.is_some() {
-                remove_dir_all(&toolchain_path)?;
+}
+
+impl<'a> Installer<'a> {
+    fn install_single_toolchain(&self, toolchain: &Toolchain<'_>) -> Result<(), Error> {
+        let toolchain_path = self.toolchains_path.join(&toolchain.dest);
+        if toolchain_path.is_dir() {
+            if self.force {
+                if self.actually_install {
+                    remove_dir_all(&toolchain_path)?;
+                }
+            } else {
+                eprintln!(
+                    "toolchain `{}` is already installed",
+                    toolchain.dest.display()
+                );
+                return Ok(());
             }
+        }
+
+        let channel = if let Some(channel) = self.override_channel {
+            Cow::Borrowed(channel)
         } else {
+            Cow::Owned(get_channel(self.client, self.prefix, toolchain.commit)?)
+        };
+
+        let downloader = TarXzDownloader {
+            client: self.actually_install.then_some(self.client),
+            toolchain,
+            channel: &channel,
+            retry: self.retry,
+        };
+
+        // download every component except rust-std.
+        for component in once(&"rustc").chain(toolchain.components) {
+            let component_filename = if *component == "rust-src" {
+                // rust-src is the only target-independent component
+                format_args!("{component}-{channel}")
+            } else {
+                format_args!("{component}-{channel}-{}", toolchain.host_target)
+            };
+            downloader.download(
+                &format!(
+                    "{}/{}/{component_filename}.tar.xz",
+                    self.prefix, toolchain.commit
+                ),
+                component,
+                toolchain.host_target,
+            )?;
+        }
+
+        // download rust-std for every target.
+        for target in toolchain.rust_std_targets {
+            downloader.download(
+                &format!(
+                    "{}/{}/rust-std-{channel}-{target}.tar.xz",
+                    self.prefix, toolchain.commit,
+                ),
+                "rust-std",
+                target,
+            )?;
+        }
+
+        // install
+        if self.actually_install {
+            rename(&toolchain.dest, toolchain_path)?;
             eprintln!(
-                "toolchain `{}` is already installed",
+                "toolchain `{}` is successfully installed!",
                 toolchain.dest.display()
             );
-            return Ok(());
-        }
-    }
-
-    let downloader = TarXzDownloader {
-        client: maybe_dry_client,
-        toolchain,
-        retry,
-    };
-
-    // download every component except rust-std.
-    for component in once(&"rustc").chain(toolchain.components) {
-        let component_filename = if *component == "rust-src" {
-            // rust-src is the only target-independent component
-            format!("{component}-{}", toolchain.channel)
         } else {
-            format!(
-                "{component}-{}-{}",
-                toolchain.channel, toolchain.host_target
-            )
-        };
-        downloader.download(
-            &format!("{prefix}/{}/{component_filename}.tar.xz", toolchain.commit),
-            component,
-            toolchain.host_target,
-        )?;
-    }
+            eprintln!(
+                "toolchain `{}` will be installed to `{}` on real run",
+                toolchain.dest.display(),
+                toolchain_path.display()
+            );
+        }
 
-    // download rust-std for every target.
-    for target in toolchain.rust_std_targets {
-        let rust_std_filename = format!("rust-std-{}-{}", toolchain.channel, target);
-        downloader.download(
-            &format!("{prefix}/{}/{rust_std_filename}.tar.xz", toolchain.commit,),
-            "rust-std",
-            target,
-        )?;
+        Ok(())
     }
-
-    // install
-    if maybe_dry_client.is_some() {
-        rename(&toolchain.dest, toolchain_path)?;
-        eprintln!(
-            "toolchain `{}` is successfully installed!",
-            toolchain.dest.display()
-        );
-    } else {
-        eprintln!(
-            "toolchain `{}` will be installed to `{}` on real run",
-            toolchain.dest.display(),
-            toolchain_path.display()
-        );
-    }
-
-    Ok(())
 }
 
 fn fetch_master_commit(client: &Client, github_token: Option<&str>) -> Result<String, Error> {
@@ -525,8 +540,16 @@ fn run() -> Result<(), Error> {
             .push(fetch_master_commit(&client, args.github_token.as_deref())?);
     }
 
-    let dry_run_client = if args.dry_run { None } else { Some(&client) };
     let mut failed = false;
+    let installer = Installer {
+        client: &client,
+        actually_install: !args.dry_run,
+        override_channel: args.channel.as_deref(),
+        prefix: &prefix,
+        toolchains_path: &toolchains_path,
+        force: args.force,
+        retry: args.retry,
+    };
     for commit in args.commits {
         let dest = if let Some(name) = args.name.as_deref() {
             PathBuf::from(name)
@@ -536,27 +559,13 @@ fn run() -> Result<(), Error> {
             PathBuf::from(&commit)
         };
 
-        let channel = if let Some(channel) = args.channel.clone() {
-            channel
-        } else {
-            get_channel(&client, &prefix, &commit)?
-        };
-
-        let result = install_single_toolchain(
-            dry_run_client,
-            &prefix,
-            &toolchains_path,
-            &Toolchain {
-                commit: &commit,
-                host_target: &args.host,
-                rust_std_targets: &rust_std_targets,
-                components: &components,
-                channel: &channel,
-                dest,
-            },
-            args.force,
-            args.retry,
-        );
+        let result = installer.install_single_toolchain(&Toolchain {
+            commit: &commit,
+            host_target: &args.host,
+            rust_std_targets: &rust_std_targets,
+            components: &components,
+            dest,
+        });
 
         if args.keep_going {
             if let Err(err) = result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,10 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::process::exit;
+use std::thread::sleep;
 use std::time::Duration;
 
-use anyhow::{Context, Error, bail, ensure};
+use anyhow::{Context, Error, anyhow, bail, ensure};
 use clap::{Parser, crate_version};
 use colored::Colorize;
 use pbr::{ProgressBar, Units};
@@ -24,6 +25,9 @@ use tempfile::{tempdir, tempdir_in};
 use xz2::read::XzDecoder;
 
 static SUPPORTED_CHANNELS: &[&str] = &["nightly", "beta", "stable"];
+
+const MIN_RETRY_SLEEP: Duration = Duration::from_millis(250);
+const MAX_RETRY_SLEEP: Duration = Duration::from_secs(60);
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Parser, Debug)]
@@ -53,8 +57,13 @@ struct Args {
     )]
     server: String,
 
-    #[arg(short = 'i', long = "host", help = "the triple of the host platform")]
-    host: Option<String>,
+    #[arg(
+        short = 'i',
+        long = "host",
+        help = "the triple of the host platform",
+        default_value = env!("HOST")
+    )]
+    host: String,
 
     #[arg(
         short = 't',
@@ -110,93 +119,162 @@ struct Args {
         help = "Continue downloading toolchains even if some of them failed"
     )]
     keep_going: bool,
+
+    #[arg(
+        long = "retry",
+        short = 'r',
+        help = "Maximum number of retries for xz downloads",
+        default_value = "0"
+    )]
+    retry: u32,
 }
 
-fn download_tar_xz(
-    client: Option<&Client>,
-    url: &str,
-    dest: &Path,
-    commit: &str,
-    component: &str,
-    channel: &str,
-    target: &str,
-) -> Result<(), Error> {
-    eprintln!("downloading <{url}>...");
-    if let Some(client) = client {
-        let response = client.get(url).send()?;
+struct RetryableError {
+    error: Error,
+    should_retry: bool,
+}
 
-        match response.status() {
-            StatusCode::OK => {}
-            StatusCode::NOT_FOUND => bail!(
-                "missing component `{}` on toolchain `{}` on channel `{}` for target `{}`",
-                component,
-                commit,
-                channel,
-                target,
-            ),
-            status => bail!("received status {} for GET {}", status, url),
-        };
+impl RetryableError {
+    fn retryable<E: Into<Error>>(err: E) -> Self {
+        Self {
+            error: err.into(),
+            should_retry: true,
+        }
+    }
+}
 
-        let length = response
-            .headers()
-            .get(CONTENT_LENGTH)
-            .and_then(|h| h.to_str().ok())
-            .and_then(|h| h.parse().ok())
-            .unwrap_or(0);
+impl<E: Into<Error>> From<E> for RetryableError {
+    fn from(err: E) -> Self {
+        Self {
+            error: err.into(),
+            should_retry: false,
+        }
+    }
+}
 
-        let err = stderr();
-        let lock = err.lock();
-        let mut progress_bar = ProgressBar::on(lock, length);
-        progress_bar.set_units(Units::Bytes);
-        progress_bar.set_max_refresh_rate(Some(Duration::from_secs(1)));
+#[derive(Debug)]
+struct TarXzDownloader<'a> {
+    client: Option<&'a Client>,
+    toolchain: &'a Toolchain<'a>,
+    retry: u32,
+}
 
-        let response = TeeReader::new(response, &mut progress_bar);
-        let response = XzDecoder::new(response);
-        for entry in Archive::new(response).entries()? {
-            let mut entry = entry?;
-            let relpath = entry.path()?;
-
-            let mut components = relpath.components();
-
-            // Reject path components that are not normal (.|..|/| etc)
-            for part in components.clone() {
-                match part {
-                    std::path::Component::Normal(_) => {}
-                    _ => bail!("bad path in tar: {}", relpath.display()),
+impl<'a> TarXzDownloader<'a> {
+    fn download(&self, url: &str, component: &str, target: &str) -> Result<(), Error> {
+        let mut attempt = 0;
+        let mut sleep_duration = MIN_RETRY_SLEEP;
+        // we should probably use `tower::retry::backoff` here,
+        //  but we need to refactor the program to use async first.
+        // note that we can't use `reqwest::retry`
+        //  because it can't handle TCP RST after the header is received when reading the body
+        loop {
+            match self.download_once(url, component, target) {
+                Ok(()) => return Ok(()),
+                Err(err) if err.should_retry && attempt < self.retry => {
+                    report_warn(&err.error);
+                    eprintln!(
+                        "download failed, going to retry after {sleep_duration:?} ({attempt}/{})",
+                        self.retry
+                    );
+                    sleep(sleep_duration);
+                    attempt += 1;
+                    sleep_duration = MAX_RETRY_SLEEP.min(sleep_duration * 2);
                 }
-            }
-
-            // Throw away the first two path components: our root was supplied
-            components.next();
-            components.next();
-
-            let full_path = dest.join(components.as_path());
-            if full_path == dest {
-                // The tmp dir code makes the root dir for us.
-                continue;
-            }
-
-            // Bail out if we get hard links, device nodes or any other unusual content
-            // - it is most likely an attack, as rusts cross-platform nature precludes
-            // such artifacts
-            let kind = entry.header().entry_type();
-
-            match kind {
-                tar::EntryType::Directory => {
-                    create_dir_all(full_path)?;
-                }
-                tar::EntryType::Regular => {
-                    entry.unpack(full_path)?;
-                }
-                _ => bail!("unsupported tar entry: {:?}", kind),
+                Err(err) => return Err(err.error),
             }
         }
-
-        progress_bar.finish();
-        eprintln!();
     }
 
-    Ok(())
+    fn download_once(
+        &self,
+        url: &str,
+        component: &str,
+        target: &str,
+    ) -> Result<(), RetryableError> {
+        eprintln!("downloading <{url}>...");
+        if let Some(client) = self.client {
+            let response = client.get(url).send().map_err(RetryableError::retryable)?;
+
+            let status = response.status();
+            if status != StatusCode::OK {
+                return Err(RetryableError {
+                    error: if status == StatusCode::NOT_FOUND {
+                        anyhow!(
+                            "missing component `{component}` on toolchain `{}` on channel `{}` for target `{target}`",
+                            self.toolchain.commit,
+                            self.toolchain.channel,
+                        )
+                    } else {
+                        anyhow!("received status {status} for GET {url}")
+                    },
+                    should_retry: status.is_server_error(),
+                });
+            }
+
+            let length = response
+                .headers()
+                .get(CONTENT_LENGTH)
+                .and_then(|h| h.to_str().ok())
+                .and_then(|h| h.parse().ok())
+                .unwrap_or(0);
+
+            let err = stderr();
+            let lock = err.lock();
+            let mut progress_bar = ProgressBar::on(lock, length);
+            progress_bar.set_units(Units::Bytes);
+            progress_bar.set_max_refresh_rate(Some(Duration::from_secs(1)));
+
+            let response = TeeReader::new(response, &mut progress_bar);
+            let response = XzDecoder::new(response);
+            for entry in Archive::new(response)
+                .entries()
+                .map_err(RetryableError::retryable)?
+            {
+                let mut entry = entry.map_err(RetryableError::retryable)?;
+                let relpath = entry.path()?;
+
+                let mut components = relpath.components();
+
+                // Reject path components that are not normal (.|..|/| etc)
+                for part in components.clone() {
+                    match part {
+                        std::path::Component::Normal(_) => {}
+                        _ => return Err(anyhow!("bad path in tar: {}", relpath.display()).into()),
+                    }
+                }
+
+                // Throw away the first two path components: our root was supplied
+                components.next();
+                components.next();
+
+                let full_path = self.toolchain.dest.join(components.as_path());
+                if full_path == self.toolchain.dest {
+                    // The tmp dir code makes the root dir for us.
+                    continue;
+                }
+
+                // Bail out if we get hard links, device nodes or any other unusual content
+                // - it is most likely an attack, as rusts cross-platform nature precludes
+                // such artifacts
+                let kind = entry.header().entry_type();
+
+                match kind {
+                    tar::EntryType::Directory => {
+                        create_dir_all(full_path)?;
+                    }
+                    tar::EntryType::Regular => {
+                        entry.unpack(full_path).map_err(RetryableError::retryable)?;
+                    }
+                    _ => return Err(anyhow!("unsupported tar entry: {kind:?}").into()),
+                }
+            }
+
+            progress_bar.finish();
+            eprintln!();
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -205,17 +283,17 @@ struct Toolchain<'a> {
     host_target: &'a str,
     rust_std_targets: &'a [&'a str],
     components: &'a [&'a str],
+    channel: &'a str,
     dest: PathBuf,
 }
 
 fn install_single_toolchain(
-    client: &Client,
     maybe_dry_client: Option<&Client>,
     prefix: &str,
     toolchains_path: &Path,
     toolchain: &Toolchain<'_>,
-    override_channel: Option<&str>,
     force: bool,
+    retry: u32,
 ) -> Result<(), Error> {
     let toolchain_path = toolchains_path.join(&toolchain.dest);
     if toolchain_path.is_dir() {
@@ -232,47 +310,36 @@ fn install_single_toolchain(
         }
     }
 
-    let channel = if let Some(channel) = override_channel {
-        String::from(channel)
-    } else {
-        get_channel(client, prefix, toolchain.commit)?
+    let downloader = TarXzDownloader {
+        client: maybe_dry_client,
+        toolchain,
+        retry,
     };
 
     // download every component except rust-std.
     for component in once(&"rustc").chain(toolchain.components) {
         let component_filename = if *component == "rust-src" {
             // rust-src is the only target-independent component
-            format!("{component}-{channel}")
+            format!("{component}-{}", toolchain.channel)
         } else {
-            format!("{}-{}-{}", component, channel, toolchain.host_target)
+            format!(
+                "{component}-{}-{}",
+                toolchain.channel, toolchain.host_target
+            )
         };
-        download_tar_xz(
-            maybe_dry_client,
-            &format!(
-                "{}/{}/{}.tar.xz",
-                prefix, toolchain.commit, &component_filename
-            ),
-            &toolchain.dest,
-            toolchain.commit,
+        downloader.download(
+            &format!("{prefix}/{}/{component_filename}.tar.xz", toolchain.commit),
             component,
-            &channel,
             toolchain.host_target,
         )?;
     }
 
     // download rust-std for every target.
     for target in toolchain.rust_std_targets {
-        let rust_std_filename = format!("rust-std-{channel}-{target}");
-        download_tar_xz(
-            maybe_dry_client,
-            &format!(
-                "{}/{}/{}.tar.xz",
-                prefix, toolchain.commit, rust_std_filename
-            ),
-            &toolchain.dest,
-            toolchain.commit,
+        let rust_std_filename = format!("rust-std-{}-{}", toolchain.channel, target);
+        downloader.download(
+            &format!("{prefix}/{}/{rust_std_filename}.tar.xz", toolchain.commit,),
             "rust-std",
-            &channel,
             target,
         )?;
     }
@@ -425,15 +492,13 @@ fn run() -> Result<(), Error> {
         ));
     }
 
-    let host = args.host.as_deref().unwrap_or(env!("HOST"));
-
     let components = args.components.iter().map(Deref::deref).collect::<Vec<_>>();
 
     let rust_std_targets = args
         .targets
         .iter()
         .map(Deref::deref)
-        .chain(once(host))
+        .chain(once(&*args.host))
         .collect::<Vec<_>>();
 
     let toolchains_dir = {
@@ -471,20 +536,26 @@ fn run() -> Result<(), Error> {
             PathBuf::from(&commit)
         };
 
+        let channel = if let Some(channel) = args.channel.clone() {
+            channel
+        } else {
+            get_channel(&client, &prefix, &commit)?
+        };
+
         let result = install_single_toolchain(
-            &client,
             dry_run_client,
             &prefix,
             &toolchains_path,
             &Toolchain {
                 commit: &commit,
-                host_target: host,
+                host_target: &args.host,
                 rust_std_targets: &rust_std_targets,
                 components: &components,
+                channel: &channel,
                 dest,
             },
-            args.channel.as_deref(),
             args.force,
+            args.retry,
         );
 
         if args.keep_going {


### PR DESCRIPTION
Fix #71.

Added an `-r N` flag which allows retrying up to `N` times, with exponential backoff starting at 250ms (capped at 60s).